### PR TITLE
Allow jump button to be set for doom & heretic

### DIFF
--- a/src/setup/joystick.c
+++ b/src/setup/joystick.c
@@ -1066,7 +1066,7 @@ void ConfigJoystick(TXT_UNCAST_ARG(widget), void *user_data)
         AddJoystickControl(window, "Speed", &joybspeed);
     }
 
-    if (gamemission == hexen || gamemission == strife)
+    if (gamemission == doom || gamemission == heretic || gamemission == hexen || gamemission == strife) // [crispy]
     {
         AddJoystickControl(window, "Jump", &joybjump);
     }


### PR DESCRIPTION
Similar to having joystick look up/down for all games it's nice to be able to set a jump button for all games.